### PR TITLE
fix: cli show command unable to detect ~ in file path

### DIFF
--- a/src/classes/cli.ts
+++ b/src/classes/cli.ts
@@ -112,8 +112,12 @@ export class CLI {
     const identityFileMatch = host.match(/IdentityFile (.*)\n/);
 
     if (identityFileMatch && identityFileMatch[1]) {
-      const identityFilePath = identityFileMatch[1].trim();
-      const publicKeyPath = `${identityFilePath}.pub`;
+      let publicKeyPath = identityFileMatch[1].trim();
+
+      publicKeyPath = publicKeyPath.replace("~", os.homedir());
+      if (!publicKeyPath.endsWith(".pub")) {
+        publicKeyPath += ".pub";
+      }
 
       if (fs.existsSync(publicKeyPath)) {
         const publicKey = fs.readFileSync(publicKeyPath, "utf8");


### PR DESCRIPTION
Patch to replace `~` with home directory in IdentityFile path.

Reason: `~/.ssh` in IdentityFile path name was not being identified by fs.existsSync().

Related to: https://github.com/InderdeepBajwa/gitid/issues/7